### PR TITLE
Defer tunnel state restoration until we can accept packets

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     implementation(deps.AndroidX.sliceBuilders)
     implementation(deps.AndroidX.sliceCore)
     implementation(deps.AndroidX.sliceKtx)
+    implementation(deps.AndroidX.workmanager)
     implementation(deps.Material.material)
     implementation(deps.ThirdParty.koinAndroid)
     implementation(deps.ThirdParty.koinCore)

--- a/app/src/main/java/com/wireguard/android/work/TunnelRestoreWork.kt
+++ b/app/src/main/java/com/wireguard/android/work/TunnelRestoreWork.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017-2019 WireGuard LLC.
+ * Copyright © 2018-2019 Harsh Shandilya <msfjarvis@gmail.com>. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.wireguard.android.work
+
+import android.content.Context
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import com.wireguard.android.di.ext.injectRootShell
+import com.wireguard.android.di.ext.injectTunnelManager
+import com.wireguard.android.model.TunnelManager
+import com.wireguard.android.util.ExceptionLoggers
+import com.wireguard.android.util.RootShell
+import org.koin.core.KoinComponent
+import timber.log.Timber
+
+class TunnelRestoreWork(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : Worker(appContext, workerParams), KoinComponent {
+    private val tunnelManager: TunnelManager by injectTunnelManager()
+    private val rootShell: RootShell by injectRootShell()
+
+    override fun doWork(): Result {
+        val result = ArrayList<String>()
+        rootShell.run(result, "iptables -L | grep Chain")
+        rootShell.run(result, "ip6tables -L | grep Chain")
+        Timber.tag("RestoreWork")
+        val isDropping = result.any { it.contains("DROP") }
+        if (isDropping) {
+            // AFWall+ sets all packets to DROP to prevent leaks during boot.
+            // Trying to start a WireGuard tunnel in this phase will end badly, so
+            // defer the job for later.
+            Timber.d("Packets are currently being dropped, defer tunnel state restore")
+            return Result.retry()
+        } else {
+            Timber.d("Restoring tunnel state")
+            tunnelManager.restoreState(false).whenComplete(ExceptionLoggers.D)
+        }
+        return Result.success()
+    }
+}

--- a/buildSrc/src/main/kotlin/DependencyStore.kt
+++ b/buildSrc/src/main/kotlin/DependencyStore.kt
@@ -15,6 +15,7 @@ class DependencyStore {
         private const val preferenceVersion = "1.1.0-rc01"
         private const val slicesVersion = "1.1.0-alpha01"
         private const val slicesKtxVersion = "1.0.0-alpha07"
+        private const val workVersion = "2.2.0-rc01"
 
         const val annotations = "androidx.annotation:annotation:$annotationVersion"
         const val appcompat = "androidx.appcompat:appcompat:$appcompatVersion"
@@ -27,6 +28,7 @@ class DependencyStore {
         const val sliceBuilders = "androidx.slice:slice-builders:$slicesVersion"
         const val sliceCore = "androidx.slice:slice-core:$slicesVersion"
         const val sliceKtx = "androidx.slice:slice-builders-ktx:$slicesKtxVersion"
+        const val workmanager = "androidx.work:work-runtime-ktx:$workVersion"
     }
 
     object Debugging {


### PR DESCRIPTION
Firewalls like AFWall+ use a startup script that uses iptables
to drop all packets during boot to prevent startup leaks. Trying to start a tunnel at this stage will not work and the tunnel might never recover either, so we defer this until iptables rules are restored by the concerned firewall.