### PR TITLE
Add running time to tunnel notifications

### DIFF
--- a/app/src/main/java/com/wireguard/android/backend/WgQuickBackend.kt
+++ b/app/src/main/java/com/wireguard/android/backend/WgQuickBackend.kt
@@ -116,6 +116,8 @@ class WgQuickBackend(private var context: Context) : Backend {
                     .setContentText(tunnel.name)
                     .setContentIntent(pendingIntent)
                     .setOngoing(true)
+                    .setShowWhen(true)
+                    .setUsesChronometer(true)
                     .setPriority(Notification.FLAG_ONGOING_EVENT)
                     .setSmallIcon(R.drawable.ic_qs_tile)
             notificationManager.notify(tunnel.name.hashCode(), builder.build())


### PR DESCRIPTION
Use foreground notification instead of notification manager.
Test on devices with SDK version < 26. 

Signed-off-by: Aditya Wasan <adityawasan55@gmail.com>