### PR TITLE
Add native Tasker integation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 - Update libwg-go and build with Go 1.13.3
+- Add Tasker plugin support to simplify integration (by Rafhaan Shah)
 
 ### [v5.2.5](https://github.com/msfjarvis/viscerion/releases/5.2.5)
 - Resolve crashes with QR import dialog on release builds

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -64,6 +64,15 @@
             android:name=".activity.TunnelCreatorActivity"
             android:label="@string/create_activity_title"
             android:parentActivityName=".activity.MainActivity" />
+			
+		<activity
+            android:name=".activity.TaskerActivity"
+            android:icon="@mipmap/ic_launcher"
+            android:label="@string/app_name" >
+            <intent-filter>
+                <action android:name="com.twofortyfouram.locale.intent.action.EDIT_SETTING" />
+            </intent-filter>
+        </activity>
 
         <receiver android:name=".services.BootShutdownReceiver">
             <intent-filter>
@@ -82,6 +91,7 @@
             <intent-filter>
                 <action android:name="${applicationId}.SET_TUNNEL_UP" />
                 <action android:name="${applicationId}.SET_TUNNEL_DOWN" />
+				<action android:name="com.twofortyfouram.locale.intent.action.FIRE_SETTING" />
             </intent-filter>
         </receiver>
 

--- a/app/src/main/java/com/wireguard/android/activity/TaskerActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/TaskerActivity.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017-2019 WireGuard LLC.
+ * Copyright © 2018-2019 Harsh Shandilya <msfjarvis@gmail.com>. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.wireguard.android.activity
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.MenuItem
+import android.view.inputmethod.InputMethodManager
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.getSystemService
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ObservableBoolean
+import com.wireguard.android.BuildConfig
+import com.wireguard.android.R
+import com.wireguard.android.databinding.TaskerActivityBinding
+import com.wireguard.android.model.TunnelManager
+
+class TaskerActivity : AppCompatActivity() {
+
+    val EXTRA_STRING_BLURB = "com.twofortyfouram.locale.intent.extra.BLURB"
+    val EXTRA_BUNDLE = "com.twofortyfouram.locale.intent.extra.BUNDLE"
+
+    private var binding: TaskerActivityBinding? = null
+    val enableTunnel = ObservableBoolean()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        supportActionBar?.let {
+            it.setDisplayHomeAsUpEnabled(true)
+            it.setDisplayShowHomeEnabled(true)
+        }
+
+        binding = DataBindingUtil.setContentView(this, R.layout.tasker_activity)
+        binding?.activity = this
+        binding?.taskerSaveButton?.setOnClickListener {
+            saveTaskerAction()
+        }
+
+        intent.getBundleExtra(EXTRA_BUNDLE)?.let {
+            binding?.taskerTunnelName?.setText(it.getString(TunnelManager.TUNNEL_NAME_INTENT_EXTRA))
+            binding?.taskerSecret?.setText(it.getString(TunnelManager.INTENT_INTEGRATION_SECRET_EXTRA))
+            enableTunnel.set(it.getString(TunnelManager.TUNNEL_STATE_INTENT_EXTRA) == "${BuildConfig.APPLICATION_ID}.SET_TUNNEL_UP")
+        }
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            android.R.id.home -> {
+                onBackPressed()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun saveTaskerAction() {
+        hideKeyboard()
+        val resultIntent = Intent()
+
+        if (binding?.taskerTunnelName?.text.toString().isBlank()) {
+            setResult(RESULT_CANCELED, resultIntent)
+            super.finish()
+            return
+        }
+
+        val bundle = Bundle()
+
+        bundle.putString(TunnelManager.TUNNEL_NAME_INTENT_EXTRA, binding?.taskerTunnelName?.text.toString())
+        bundle.putString(TunnelManager.INTENT_INTEGRATION_SECRET_EXTRA, binding?.taskerSecret?.text.toString())
+
+        if (enableTunnel.get()) {
+            bundle.putString(TunnelManager.TUNNEL_STATE_INTENT_EXTRA, "${BuildConfig.APPLICATION_ID}.SET_TUNNEL_UP")
+            resultIntent.putExtra(EXTRA_STRING_BLURB, getString(R.string.enable_tunnel, binding?.taskerTunnelName?.text))
+        } else {
+            bundle.putString(TunnelManager.TUNNEL_STATE_INTENT_EXTRA, "${BuildConfig.APPLICATION_ID}.SET_TUNNEL_DOWN")
+            resultIntent.putExtra(EXTRA_STRING_BLURB, getString(R.string.disable_tunnel, binding?.taskerTunnelName?.text))
+        }
+
+        resultIntent.putExtra(EXTRA_BUNDLE, bundle)
+        setResult(RESULT_OK, resultIntent)
+        super.finish()
+    }
+
+    private fun hideKeyboard() {
+        currentFocus?.let {
+            getSystemService<InputMethodManager>()?.hideSoftInputFromWindow(
+                    it.windowToken,
+                    InputMethodManager.HIDE_NOT_ALWAYS
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
+++ b/app/src/main/java/com/wireguard/android/model/TunnelManager.kt
@@ -261,6 +261,7 @@ class TunnelManager(private val context: Context) : BaseObservable(), KoinCompon
         const val NOTIFICATION_CHANNEL_ID = "wg-quick_tunnels"
         const val TUNNEL_NAME_INTENT_EXTRA = "tunnel_name"
         const val INTENT_INTEGRATION_SECRET_EXTRA = "integration_secret"
+        const val TUNNEL_STATE_INTENT_EXTRA = "tunnel_state"
         private val asyncWorker by injectAsyncWorker()
         private val backend by injectBackend()
 

--- a/app/src/main/java/com/wireguard/android/services/TaskerIntegrationReceiver.kt
+++ b/app/src/main/java/com/wireguard/android/services/TaskerIntegrationReceiver.kt
@@ -17,12 +17,17 @@ import org.koin.core.KoinComponent
 import timber.log.Timber
 
 class TaskerIntegrationReceiver : BroadcastReceiver(), KoinComponent {
+    val ACTION_FIRE_SETTING = "com.twofortyfouram.locale.intent.action.FIRE_SETTING"
     val manager = getTunnelManager()
     val prefs = getPrefs()
 
     override fun onReceive(context: Context?, intent: Intent?) {
         if (intent == null || intent.action == null)
             return
+
+        if (intent.action == ACTION_FIRE_SETTING) {
+            intent.action = intent.getStringExtra(TunnelManager.TUNNEL_STATE_INTENT_EXTRA)
+        }
 
         val isSelfPackage = intent.`package` == BuildConfig.APPLICATION_ID
         val taskerEnabled = !prefs.allowTaskerIntegration || prefs.taskerIntegrationSecret.isEmpty()

--- a/app/src/main/res/layout/tasker_activity.xml
+++ b/app/src/main/res/layout/tasker_activity.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <data>
+
+        <variable
+            name="activity"
+            type="com.wireguard.android.activity.TaskerActivity" />
+
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="8dp"
+        android:background="?attr/colorBackground"
+        android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/TextInputLayoutBase"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tasker_tunnel_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/tunnel_name" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            style="@style/TextInputLayoutBase"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="4dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/tasker_secret"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/tasker_integration_secret" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Switch
+            android:id="@+id/tasker_tunnel_enable_switch"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:checked="@={activity.enableTunnel}"
+            android:text="@string/tasker_integration_enable_or_disable_tunnel" />
+
+        <Button
+            android:id="@+id/tasker_save_button"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@string/save" />
+
+    </LinearLayout>
+
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,8 +67,10 @@
     <string name="create_tunnel">Create Tunnel</string>
     <string name="delete">Delete</string>
     <string name="deselect_all">Deselect All</string>
+    <string name="disable_tunnel">Disable tunnel: %s</string>
     <string name="dns_servers">DNS servers</string>
     <string name="edit">Edit</string>
+    <string name="enable_tunnel">Enable tunnel: %s</string>
     <string name="endpoint">Endpoint</string>
     <string name="error_down">Error bringing down tunnel: %s</string>
     <string name="error_fetching_apps">Error fetching apps list: %s</string>
@@ -178,7 +180,9 @@
     <string name="preference_category_theming">Theming</string>
     <string name="preference_category_misc">Misc</string>
     <string name="tasker_integration_title">Enable tasker integration</string>
+    <string name="tasker_integration_enable_or_disable_tunnel">Enable / Disable Tunnel</string>
     <string name="tasker_integration_summary">WARNING: This is a potential security risk! Avoid using this on rooted devices, malicious apps can very easily circumvent the protection put in place by Viscerion!</string>
+    <string name="tasker_integration_secret">Tasker Secret</string>
     <string name="tasker_integration_secret_title">External intent secret</string>
     <string name="tasker_integration_secret_summary">Secured secret to ensure only trusted clients can control tunnels. This cannot be empty!</string>
     <string name="tasker_integration_summary_empty_secret">Setting a secret here is mandatory!</string>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [x] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
<!--- Describe your changes in detail -->
This adds native Tasker integration, allowing users to enable / disable tunnels via an actual Tasker action, instead of having to use intents.

I've tried not to change too much of the existing code, and you will probably want to clean up somethings, but please let me know if there's anything you would like me to improve!

I followed these pages to enable Tasker integration:
https://tasker.joaoapps.com/plugins-intro.html
https://github.com/twofortyfouram/android-toast-setting-plugin-for-locale

As well as referencing the implementation in:
https://github.com/nosybore/Tasker-MQTT-Publish-Plugin
https://github.com/termux/termux-tasker

## :bulb: Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The motivation for this change was to make it easier for users to enable or disable the VPN tunnels using Tasker.

## :green_heart: How did you test it?
Tested on a Google Pixel 3a on Android 10 with the latest version of Tasker, v5.8.5.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code

## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->

<img src="https://i.imgur.com/9vhZvkV.png" width="260">&emsp;<img src="https://i.imgur.com/Q3vTpYR.png" width="260">

