### PR TITLE
Cleanup existing SDK 29 workarounds and add more

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -74,6 +74,9 @@
             </intent-filter>
         </activity>
 
+        <activity android:name=".activity.TunnelToggleActivity"
+            android:theme="@style/NoBackgroundTheme" />
+
         <receiver android:name=".services.BootShutdownReceiver">
             <intent-filter>
                 <action android:name="android.intent.action.ACTION_SHUTDOWN" />

--- a/app/src/main/java/com/wireguard/android/activity/TunnelToggleActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/TunnelToggleActivity.kt
@@ -29,11 +29,10 @@ class TunnelToggleActivity : AppCompatActivity() {
         tunnel.setState(Tunnel.State.TOGGLE).whenComplete { _, throwable ->
             TileService.requestListeningState(this, ComponentName(this, QuickTileService::class.java))
             onToggleFinished(throwable)
-            finish()
+            finishAffinity()
         }
     }
 
-    // Duplicated from QuickTileService
     private fun onToggleFinished(throwable: Throwable?) {
         throwable ?: return
         val error = ErrorMessages[throwable]

--- a/app/src/main/java/com/wireguard/android/activity/TunnelToggleActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/TunnelToggleActivity.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright © 2017-2019 WireGuard LLC.
+ * Copyright © 2018-2019 Harsh Shandilya <msfjarvis@gmail.com>. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package com.wireguard.android.activity
+
+import android.content.ComponentName
+import android.os.Bundle
+import android.service.quicksettings.TileService
+import android.widget.Toast
+import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatActivity
+import com.wireguard.android.R
+import com.wireguard.android.di.ext.getTunnelManager
+import com.wireguard.android.model.Tunnel
+import com.wireguard.android.services.QuickTileService
+import com.wireguard.android.util.ErrorMessages
+import timber.log.Timber
+
+@RequiresApi(29)
+class TunnelToggleActivity : AppCompatActivity() {
+
+    private val tunnelManager = getTunnelManager()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val tunnel = tunnelManager.getLastUsedTunnel() ?: return
+        tunnel.setState(Tunnel.State.TOGGLE).whenComplete { _, throwable ->
+            TileService.requestListeningState(this, ComponentName(this, QuickTileService::class.java))
+            onToggleFinished(throwable)
+            finish()
+        }
+    }
+
+    // Duplicated from QuickTileService
+    private fun onToggleFinished(throwable: Throwable?) {
+        throwable ?: return
+        val error = ErrorMessages[throwable]
+        val message = getString(R.string.toggle_error, error)
+        Timber.e(throwable)
+        Toast.makeText(this, message, Toast.LENGTH_LONG).show()
+    }
+}

--- a/app/src/main/java/com/wireguard/android/services/QuickTileService.kt
+++ b/app/src/main/java/com/wireguard/android/services/QuickTileService.kt
@@ -93,9 +93,10 @@ class QuickTileService : TileService() {
                 tile.updateTile()
             }
             tunnel?.setState(State.TOGGLE)?.whenComplete { _, throwable ->
+                updateTile()
                 this.onToggleFinished(throwable)
             }
-        } else if (Build.VERSION.SDK_INT < 29) {
+        } else {
             val intent = Intent(this, LaunchActivity::class.java)
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             startActivityAndCollapse(intent)
@@ -141,7 +142,7 @@ class QuickTileService : TileService() {
                 Tile.STATE_INACTIVE
         } else {
             label = getString(R.string.app_name)
-            state = if (Build.VERSION.SDK_INT >= 29) Tile.STATE_UNAVAILABLE else Tile.STATE_INACTIVE
+            state = Tile.STATE_INACTIVE
         }
         tile.label = label
         if (tile.state != state) {

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -24,6 +24,19 @@
         <item name="android:windowBackground">?attr/colorBackground</item>
     </style>
 
+    <style name="NoBackgroundTheme" parent="AppTheme">
+        <item name="android:windowIsTranslucent">true</item>
+        <item name="android:windowContentOverlay">@null</item>
+        <item name="android:windowNoTitle">true</item>
+        <item name="android:windowActionBar">false</item>
+        <item name="android:windowBackground">@android:color/transparent</item>
+        <item name="android:background">@android:color/transparent</item>
+        <item name="colorPrimaryDark">@android:color/transparent</item>
+        <item name="android:backgroundDimEnabled">true</item>
+        <item name="android:windowEnterAnimation">@android:anim/fade_in</item>
+        <item name="android:windowExitAnimation">@android:anim/fade_out</item>
+    </style>
+
     <style name="BaseBottomSheetDialog" parent="ThemeOverlay.MaterialComponents.BottomSheetDialog">
         <item name="android:windowIsFloating">false</item>
         <item name="android:navigationBarColor">?attr/colorBackground</item>


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
To mitigate this situation, we introduce a proxy activity of sorts that will handle starting VpnService for us. The activity is completely transparent and invisible, and does only four things:

- Toggle the tunnel state
- Request the Tile bound by QuickTileService to refresh its state
- Handle any error that might have been thrown during toggle
- Call finish() and go away

Since this service-activity-service cycle is a bit slow, we restrict to using this only when we absolutely need to: On Android 29, using GoBackend, when starting the tunnel.

## :bulb: Motivation and Context
On Android 10, apps cannot start services when they're in the background. This means that starting VpnService from within QuickTileService when the app is not active ends badly.


## :green_heart: How did you test it?
Tested manually

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->