### PR TITLE
Allow userspace backend to restore tunnel state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Release Notes
 
 ### [Unreleased]
+- Allow userspace mode to persist tunnels across reboots
 
 ### [5.2.8] - 2019-01-11
 - Workaround background service restrictions on Android 10

--- a/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
+++ b/app/src/main/java/com/wireguard/android/activity/SettingsActivity.kt
@@ -87,8 +87,7 @@ class SettingsActivity : AppCompatActivity() {
             val screen = preferenceScreen
             val ctx = requireContext()
             val wgQuickOnlyPrefs = arrayOf(
-                    screen.findPreference<Preference>("tools_installer"),
-                    screen.findPreference<CheckBoxPreference>("restore_on_boot")
+                    screen.findPreference<Preference>("tools_installer")
             )
             val wgOnlyPrefs = arrayOf(
                     screen.findPreference<CheckBoxPreference>("whitelist_exclusions")

--- a/app/src/main/java/com/wireguard/android/services/BootShutdownReceiver.kt
+++ b/app/src/main/java/com/wireguard/android/services/BootShutdownReceiver.kt
@@ -30,21 +30,23 @@ class BootShutdownReceiver : BroadcastReceiver() {
         if (intent.action == null) return
         getInjector(context).inject(this)
         backendAsync.thenAccept { backend ->
-            if (backend !is WgQuickBackend) {
-                return@thenAccept
-            }
             val action = intent.action
             if (Intent.ACTION_BOOT_COMPLETED == action) {
                 Timber.i("Broadcast receiver attempting to restore state (boot)")
-                val restoreWork = OneTimeWorkRequestBuilder<TunnelRestoreWorker>()
-                        .setBackoffCriteria(
-                                BackoffPolicy.LINEAR,
-                                OneTimeWorkRequest.MIN_BACKOFF_MILLIS,
-                                TimeUnit.MILLISECONDS
-                        )
-                        .addTag("restore_work")
-                        .build()
-                WorkManager.getInstance(context).enqueue(restoreWork)
+                if (backend is WgQuickBackend) {
+                    val restoreWork = OneTimeWorkRequestBuilder<TunnelRestoreWorker>()
+                            .setBackoffCriteria(
+                                    BackoffPolicy.LINEAR,
+                                    OneTimeWorkRequest.MIN_BACKOFF_MILLIS,
+                                    TimeUnit.MILLISECONDS
+                            )
+                            .addTag("restore_work")
+                            .build()
+                    WorkManager.getInstance(context).enqueue(restoreWork)
+                } else {
+                    Timber.d("Restoring tunnel state")
+                    tunnelManager.restoreState(false).whenComplete(ExceptionLoggers.D)
+                }
             } else if (Intent.ACTION_SHUTDOWN == action) {
                 Timber.i("Broadcast receiver saving state (shutdown)")
                 tunnelManager.saveState()

--- a/app/src/main/java/com/wireguard/android/services/BootShutdownReceiver.kt
+++ b/app/src/main/java/com/wireguard/android/services/BootShutdownReceiver.kt
@@ -16,6 +16,7 @@ import com.wireguard.android.backend.WgQuickBackend
 import com.wireguard.android.di.getInjector
 import com.wireguard.android.model.TunnelManager
 import com.wireguard.android.util.BackendAsync
+import com.wireguard.android.util.ExceptionLoggers
 import com.wireguard.android.work.TunnelRestoreWorker
 import java.util.concurrent.TimeUnit
 import javax.inject.Inject


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- Put an `x` in the boxes that apply -->
- [ ] Bugfix
- [ ] New feature
- [x] Enhancement
- [ ] Refactoring


## :scroll: Description
Remove restriction from userspace backend about restoring state on reboot

## :bulb: Motivation and Context
Fixes #210

## :green_heart: How did you test it?
Enable a tunnel, select restore on boot in settings, then reboot and unlock device. Within a few seconds, the tunnel will be connected as confirmed by the VPN icon in the statusbar.

## :pencil: Checklist
<!--- Put an `x` in the boxes that apply -->
- [x] I ran `./gradlew spotlessApply` before submitting the PR
- [x] I reviewed submitted code


## :crystal_ball: Next steps


## :camera_flash: Screenshots / GIFs
<!--- Mandatory for UI changes -->
<!-- Uncomment the next line and replace it with links to your screenshots. -->
<!--
<img src="https://placekitten.com/260/260" width="260">&emsp;<img src="https://placekitten.com/300/300" width="260">
-->